### PR TITLE
Make test decimal parsing more lenient

### DIFF
--- a/test/decimal_test.ml
+++ b/test/decimal_test.ml
@@ -38,15 +38,19 @@ let eval_test_case {
   operation;
   operands;
   expected_result;
-  expected_exceptions;
+  expected_signals;
 } =
   let context = C.copy ~orig () in
   print_endline test_id;
   begin match operation, operands with
-  | Add, [t1; t2] -> assert (D.add ~context t1 t2 = expected_result)
+  | Add, [t1; t2] ->
+      let t1 = D.of_string t1 in
+      let t2 = D.of_string t2 in
+      let expected_result = D.of_string expected_result in
+      assert (D.add ~context t1 t2 = expected_result)
   | _ -> ()
   end;
-  List.iter (flag_was_set context) expected_exceptions
+  List.iter (flag_was_set context) expected_signals
 
 let eval_test_line = function
   | P.Directive test_directive -> eval_test_directive test_directive


### PR DESCRIPTION
Hi! I took a look at the changes and I think you shouldn't convert to decimal with D.of_string during the parsing, because:

- some of the tests are specifically to test the parsing of the numbers, so they contain invalid inputs
- there's some special strings like `#` which have a special meaning (see the _Format-dependent representation_ section on [this page](http://speleotrove.com/decimal/dtfile.html))

Plus you already have a working parser in the library itself, so perhaps it'd be best not to duplicate the effort.

So considering that I've restored the more wonky parser for decimals I wrote and cleaned it up a bit, plus and a few other things which I meant to do yesterday. I tested the parser again with all of the test suite and now the quoted numbers are parsed correctly.