### PR TITLE
feat: implement `to_float`

### DIFF
--- a/lib/decimal.ml
+++ b/lib/decimal.ml
@@ -507,6 +507,12 @@ let to_string ?(eng=false) ?(context= !Context.default) = function
 
 let to_yojson t = `String (to_string t)
 
+let to_float ?(context= !Context.default) = function
+  | NaN -> Float.nan
+  | Inf Pos -> Float.infinity
+  | Inf Neg -> Float.neg_infinity
+  | (Finite _) as d -> float_of_string (to_string ~context d)
+
 let pp f t = t |> to_string |> Format.pp_print_string f
 
 let z10 = Calc.z10

--- a/lib/decimal.mli
+++ b/lib/decimal.mli
@@ -337,6 +337,12 @@ val to_yojson : t -> [> `String of string]
 
     @since 0.3.0 *)
 
+val to_float : ?context:Context.t -> t -> float
+[@@alert lossy "Suffers from floating-point precision loss. Other serializations should be preferred."]
+(** [to_float ?context decimal] is the float representation of the [decimal]. This
+    suffers from floating-point precision loss; the other serializations should be
+    preferred. *)
+
 val pp : Format.formatter -> t -> unit
 
 val to_tuple : t -> int * string * int


### PR DESCRIPTION
This might be a bit controversial, but I think it's worth including. A lot of the time a more "precise" decimal library like this will be used to carry out intermediate calculations, and then the final result will be converted to a binary FP number. I kept a similar alert as is included w/ `of_float`.

Also the methodology of just converting the decimal to a string and then parsing that string [is how Python does it](https://github.com/python/cpython/blob/main/Lib/_pydecimal.py#L1620), as ugly as it may look.