### PR TITLE
feat: add `?format` parameter to `to_string`

### DIFF
--- a/lib/decimal.ml
+++ b/lib/decimal.ml
@@ -490,6 +490,26 @@ let to_string ?(eng = false) ?(context = !Context.default) = function
     in
     Sign.to_string sign ^ intpart ^ fracpart ^ exp
 
+let to_decimal_string = function
+  | Inf sign -> Sign.to_string sign ^ "Infinity"
+  | NaN -> "NaN"
+  | Finite { sign; coef; exp } ->
+    (* Number of digits of coef to left of decimal point *)
+    let leftdigits = exp + String.length coef in
+
+    let intpart, fracpart =
+      if leftdigits <= 0 then
+        "0", "." ^ String.make ~-leftdigits '0' ^ coef
+      else
+        let len_coef = String.length coef in
+        if leftdigits >= len_coef then
+          coef ^ String.make (leftdigits - len_coef) '0', ""
+        else
+          ( String.sub coef 0 leftdigits,
+            "." ^ String.sub coef leftdigits (len_coef - leftdigits) )
+    in
+    Sign.to_string sign ^ intpart ^ fracpart
+
 let to_yojson t = `String (to_string t)
 
 let to_float ?(context = !Context.default) = function

--- a/lib/decimal.ml
+++ b/lib/decimal.ml
@@ -448,7 +448,7 @@ let to_bool = function
   | Finite { coef = "0"; _ } -> false
   | _ -> true
 
-let to_string ?(eng = false) ?(context = !Context.default) = function
+let to_string ?(format = `standard) ?(context = !Context.default) = function
   | Inf sign -> Sign.to_string sign ^ "Infinity"
   | NaN -> "NaN"
   | Finite { sign; coef; exp } ->
@@ -458,15 +458,20 @@ let to_string ?(eng = false) ?(context = !Context.default) = function
     (* Number of digits of coef to left of decimal point in mantissa of
        output string (i.e. after adjusting for exponent *)
     let dotplace =
-      if exp <= 0 && leftdigits > -6 then (* No exponent required *)
-        leftdigits
-      else if not eng then
-        (* Usual scientific notation: 1 digit on left of point *)
-        1
-      else if coef = "0" then (* Engineering notation, zero *)
-        ((leftdigits + 1) mod 3) - 1
-      else (* Engineering notation, nonzero *)
-        ((leftdigits - 1) mod 3) + 1
+      match format with
+      | `standard ->
+        if exp <= 0 && leftdigits > -6 then (* No exponent required *)
+          leftdigits
+        else (* Usual scientific notation: 1 digit on left of point *)
+          1
+      | `eng ->
+        if exp <= 0 && leftdigits > -6 then (* No exponent required *)
+          leftdigits
+        else if coef = "0" then (* Engineering notation, zero *)
+          ((leftdigits + 1) mod 3) - 1
+        else (* Engineering notation, nonzero *)
+          ((leftdigits - 1) mod 3) + 1
+      | `plain -> leftdigits
     in
     let intpart, fracpart =
       if dotplace <= 0 then
@@ -480,6 +485,7 @@ let to_string ?(eng = false) ?(context = !Context.default) = function
             "." ^ String.sub coef dotplace (len_coef - dotplace) )
     in
     let exp =
+      (* When format is [`plain], this is guaranteed to be 0 *)
       let value = leftdigits - dotplace in
       if value = 0 then
         ""
@@ -489,26 +495,6 @@ let to_string ?(eng = false) ?(context = !Context.default) = function
         e ^ s ^ string_of_int value
     in
     Sign.to_string sign ^ intpart ^ fracpart ^ exp
-
-let to_decimal_string = function
-  | Inf sign -> Sign.to_string sign ^ "Infinity"
-  | NaN -> "NaN"
-  | Finite { sign; coef; exp } ->
-    (* Number of digits of coef to left of decimal point *)
-    let leftdigits = exp + String.length coef in
-
-    let intpart, fracpart =
-      if leftdigits <= 0 then
-        "0", "." ^ String.make ~-leftdigits '0' ^ coef
-      else
-        let len_coef = String.length coef in
-        if leftdigits >= len_coef then
-          coef ^ String.make (leftdigits - len_coef) '0', ""
-        else
-          ( String.sub coef 0 leftdigits,
-            "." ^ String.sub coef leftdigits (len_coef - leftdigits) )
-    in
-    Sign.to_string sign ^ intpart ^ fracpart
 
 let to_yojson t = `String (to_string t)
 

--- a/lib/decimal.mli
+++ b/lib/decimal.mli
@@ -322,10 +322,13 @@ val to_bigint : t -> Z.t
 
 val to_bool : t -> bool
 val to_rational : t -> Q.t
-val to_string : ?eng:bool -> ?context:Context.t -> t -> string
 
-val to_decimal_string : t -> string
-(** [to_decimal_string t] is the decimal representation of [t], i.e. assuming [t] is finite, the only characters in the string are ['0'..'9'] and ['.']. *)
+val to_string :
+  ?format:[`standard | `eng | `plain] -> ?context:Context.t -> t -> string
+(** [to_string ?format ?context t] is the string representation of [t]. [format] is optional, defauling to [`standard], with the options being:
+  - [`standard] - numbers are represented as decimals until 6 decimal points, at which point they are represented as scientific notation
+  - [`eng] - engineering notation, where the exponent of 10 is always a multiple of 3
+  - [`plain] - "normal" decimal notation *)
 
 val to_yojson : t -> [> `String of string]
 (** [to_yojson t] is the JSON representation of decimal value [t]. Note that it

--- a/lib/decimal.mli
+++ b/lib/decimal.mli
@@ -325,7 +325,7 @@ val to_rational : t -> Q.t
 val to_string : ?eng:bool -> ?context:Context.t -> t -> string
 
 val to_decimal_string : t -> string
-(** [to_decimal_string t] is the decimal representation of [t], i.e. the only characters in the string are ['0'..'9'] and ['.']. *)
+(** [to_decimal_string t] is the decimal representation of [t], i.e. assuming [t] is finite, the only characters in the string are ['0'..'9'] and ['.']. *)
 
 val to_yojson : t -> [> `String of string]
 (** [to_yojson t] is the JSON representation of decimal value [t]. Note that it

--- a/lib/decimal.mli
+++ b/lib/decimal.mli
@@ -324,6 +324,9 @@ val to_bool : t -> bool
 val to_rational : t -> Q.t
 val to_string : ?eng:bool -> ?context:Context.t -> t -> string
 
+val to_decimal_string : t -> string
+(** [to_decimal_string t] is the decimal representation of [t], i.e. the only characters in the string are ['0'..'9'] and ['.']. *)
+
 val to_yojson : t -> [> `String of string]
 (** [to_yojson t] is the JSON representation of decimal value [t]. Note that it
     is encoded as a string to avoid losing precision.

--- a/lib/decimal.mli
+++ b/lib/decimal.mli
@@ -325,7 +325,7 @@ val to_rational : t -> Q.t
 
 val to_string :
   ?format:[`standard | `eng | `plain] -> ?context:Context.t -> t -> string
-(** [to_string ?format ?context t] is the string representation of [t]. [format] is optional, defauling to [`standard], with the options being:
+(** [to_string ?format ?context t] is the string representation of [t]. [format] is optional, defaulting to [`standard], with the options being:
   - [`standard] - numbers are represented as decimals until 6 decimal points, at which point they are represented as scientific notation
   - [`eng] - engineering notation, where the exponent of 10 is always a multiple of 3
   - [`plain] - "normal" decimal notation *)


### PR DESCRIPTION
This might be a bit controversial/not desired in this library, but we bumped up against an issue where a third party API was expecting decimal strings not in scientific/engineering notation. I thought it might make sense to upstream it in case anyone else needs it as well.