### PR TITLE
Fix test failure on ppx_decimal

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (test
  (name decimal_test)
+ (package decimal)
  (deps
   (glob_files data/*.decTest))
  (libraries alcotest angstrom decimal))


### PR DESCRIPTION
See https://discuss.ocaml.org/t/opam-ci-failing-due-to-unused-dependency/12725