### PR TITLE
fix: correctly parse small floats, use correct comparison in `add`

### DIFF
--- a/test/float.ml
+++ b/test/float.ml
@@ -2,6 +2,15 @@ open Alcotest
 module Float = Stdlib.Float
 
 let decimal = (module Decimal : TESTABLE with type t = Decimal.t)
+
+let decimal_roundtrip =
+  (module struct
+    include Decimal
+
+    let equal a b = Float.equal (to_float a) (to_float b) [@@alert "-lossy"]
+  end : TESTABLE
+    with type t = Decimal.t)
+
 let of_float = (Decimal.of_float [@alert "-lossy"])
 
 let tests =
@@ -34,4 +43,12 @@ let tests =
           begin
             fun () ->
               -0. |> of_float |> check decimal "-0.0" (Decimal.of_string "-0.0")
+          end;
+        test_case "small number" `Quick
+          begin
+            fun () ->
+              0.0000001
+              |> of_float
+              |> check decimal_roundtrip "0.0000001"
+                   (Decimal.of_string "0.0000001")
           end ] ) ]


### PR DESCRIPTION
This fixes two bugs:
- When serializing small floats, `string_of_float` uses scientific notation which the current parser doesn't account for. Furthermore, there is no way to specify the amount of precision in the resultant string.
  - **Solution**: use `Printf.sprintf` to serialize the string with the precision being `context.prec`
- When adding numbers, we check to see if they are equal but of opposite sign. This is done using string comparisons which do not take into account leading `0`s that can be added by `normalize`
	- **Solution**: parse the coefficients as `Z.t`s earlier and use those for the comparison